### PR TITLE
Add Dockerfile for building docs using Sphinx

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,19 @@
+# vim:set ft=dockerfile:
+FROM       eudat-pyhandle
+
+RUN        apt-get update && apt-get install -y --no-install-recommends \
+           make \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN        easy_install pip
+RUN        pip install \
+           sphinx
+
+VOLUME     /opt/PYHANDLE/docs
+
+WORKDIR    /opt/PYHANDLE/docs
+
+ENTRYPOINT ["make"]
+
+CMD        ["help"]


### PR DESCRIPTION
This PR adds a Dockerfile for building the documentation using Sphinx.

This will be used by the CI server in order to automatically re-build and publish the docs to the repo's GitHub Pages site whenever the master branch is updated.