### PR TITLE
Removed bad logging configuration.

### DIFF
--- a/pyhandle/__init__.py
+++ b/pyhandle/__init__.py
@@ -8,3 +8,11 @@ __version__ = "1.0.4-dev0"
 # (The first comment - empty or not - would be appended to 
 # the package name, the next non-empty comment would be
 # printed as description).
+
+from . import clientcredentials
+from . import handleclient
+
+# Make sure that a single "import pyhandle" allows the use of
+# relevant submodules!
+# See 
+# https://github.com/psf/requests/blob/master/requests/__init__.py#L120

--- a/pyhandle/client/batchhandleclient.py
+++ b/pyhandle/client/batchhandleclient.py
@@ -16,8 +16,6 @@ from pyhandle.clientcredentials import PIDClientCredentials
 
 from .. import util
 
-logging.basicConfig(level=logging.INFO)
-
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(util.NullHandler())
 


### PR DESCRIPTION
Removed log-handler, which should not be present in a library. And it made all log statements be printed double to stdout, as soon as a script using pyhandle defined its own log-handlers.
See: 
https://docs.python-guide.org/writing/logging/#logging-in-a-library
https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library